### PR TITLE
ci: compress nightly toolchain tar archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
             texinfo
 
       - name: Build toolchain
+        id: build_toolchain
         run: |
+          echo "::set-output name=toolchain_name::${{ matrix.target }}-nightly-$(date --utc '+%Y.%m.%d')"
+
           ./configure \
             --target=${{ matrix.target }} \
             --prefix=${{ env.build_dir }} \
@@ -54,16 +57,15 @@ jobs:
             --disable-werror
 
           make -j $(nproc)
-          make install
 
       - name: Create toolchain archive
         if: github.event_name == 'schedule'
         run: |
-          tar -cvf ${{ matrix.target }}-nightly.tar --owner=0 --group=0 -C ${{ env.build_dir }} .
+          tar -czvf ${{ steps.build_toolchain.outputs.toolchain_name }}.tar.gz --owner=0 --group=0 -C ${{ env.build_dir }} .
 
       - name: Upload artifacts
         if: github.event_name == 'schedule'
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.target }}-nightly
-          path: ${{ matrix.target }}-nightly.tar
+          name: ${{ steps.build_toolchain.outputs.toolchain_name }}
+          path: ${{ steps.build_toolchain.outputs.toolchain_name }}.tar.gz


### PR DESCRIPTION
Compress nightly toolchain tar archives to speed up download time.

Also, add a date in the archive name.

Signed-off-by: Artem Panfilov <artemp@synopsys.com>