### PR TITLE
CI: Run CI every day, not only Mon-Fri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: "0 0 * * 1-5"
+    - cron: "0 0 * * *"
 
 jobs:
   toolchains:


### PR DESCRIPTION
We used to have the CI running only for work days to not bother people on their weekends with reports of problems.

That in its turn postpones testing of changes done on Friday till the next Monday.

But why not running all tests daily to get rid of possible delays?