### PR TITLE
Fix GitHub CI flow to accommodate removed configure script

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -100,6 +100,8 @@ jobs:
 
           echo ::set-output name=toolchain_name::${{ matrix.target }}-${MODE}-${RELEASE_TAG}
 
+          autoconf
+
           ${{ github.workspace }}/configure \
             ${BUILD_FLAGS} \
             --target=${{ matrix.target }} \


### PR DESCRIPTION
Commit b0aa9dffe81b ("Remove configure script") as it says, removed "configure" script and since then the VI was failing. Fix it by autogeneration of the missing script before its execution as suggested by the offending commit.