### PR TITLE
Added configuration option for Simulator

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -100,17 +100,17 @@ endif
 endif
 
 ifeq ($(SIM),qemu)
-  # Using qemu simulator.
-  SIM_STAMP:= stamps/build-qemu
+	# Using qemu simulator.
+	SIM_STAMP:= stamps/build-qemu
 else
 ifeq ($(SIM),nsim)
-  # Using nsim simulator.
-  ifeq (@default_target@, linux)
-    $(error nSIM not supported)
-  endif
-  SIM_STAMP:= nsim-validation
+	# Using nsim simulator.
+	ifeq (@default_target@, linux)
+		$(error nSIM not supported)
+	endif
+	SIM_STAMP:= nsim-validation
 else
-  $(error Only support SIM=nsim, or SIM=qemu (default))
+	$(error Only support SIM=nsim, or SIM=qemu (default))
 endif
 endif
 
@@ -508,9 +508,9 @@ stamps/check-newlib-newlib: stamps/build-newlib $(SIM_STAMP)
 	date > $@
 
 nsim-validation:
-  ifeq (,$(shell command -v nsimdrv))
-    $(error nSIM not detected. Please add the tool to PATH)
-  endif
+ifeq ($(shell command -v nsimdrv),)
+	$(error nsimdrv not detected)
+endif
 
 report-gcc-newlib: stamps/check-gcc-newlib
 	$(srcdir)/scripts/testsuite-filter newlib \

--- a/Makefile.in
+++ b/Makefile.in
@@ -30,6 +30,8 @@ QEMU_SRCDIR		:= $(srcdir)/qemu
 
 SYSROOT := $(INSTALL_DIR)/sysroot
 
+SIM ?= @with_sim@
+
 SHELL := /bin/sh
 AWK := @GAWK@
 SED := @GSED@
@@ -96,9 +98,24 @@ else
 	QEMU_CPU = hs6x
 endif
 endif
-SIM_PATH:=$(srcdir)/scripts/wrapper/qemu
+
+ifeq ($(SIM),qemu)
+  # Using qemu simulator.
+  SIM_STAMP:= stamps/build-qemu
+else
+ifeq ($(SIM),nsim)
+  # Using nsim simulator.
+  ifeq (@default_target@, linux)
+    $(error nSIM not supported)
+  endif
+  SIM_STAMP:= nsim-validation
+else
+  $(error Only support SIM=nsim, or SIM=qemu (default))
+endif
+endif
+
+SIM_PATH:=$(srcdir)/scripts/wrapper/$(SIM)
 SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" ARC_SYSROOT="$(SYSROOT)" DEJAGNU="$(srcdir)/dejagnu/site.exp" QEMU_CPU="$(QEMU_CPU)"
-SIM_STAMP:= stamps/build-qemu
 
 
 all: @default_target@ @qemu_build@
@@ -489,6 +506,11 @@ stamps/check-binutils-linux: stamps/build-gcc-linux-stage2 $(SIM_STAMP)
 stamps/check-newlib-newlib: stamps/build-newlib $(SIM_STAMP)
 	$(SIM_PREPARE) $(MAKE) -C build-newlib check -k "RUNTESTFLAGS=--target_board='$(NEWLIB_TARGET_BOARDS)'" || true
 	date > $@
+
+nsim-validation:
+  ifeq (,$(shell command -v nsimdrv))
+    $(error nSIM not detected. Please add the tool to PATH)
+  endif
 
 report-gcc-newlib: stamps/check-gcc-newlib
 	$(srcdir)/scripts/testsuite-filter newlib \

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,18 @@ AS_IF([test "x$enable_qemu" != xno],
 	[AC_SUBST(qemu_build, qemu)],
 	[])
 
+AC_ARG_WITH(sim,
+		[AS_HELP_STRING([--with-sim=SIM],
+		[Sets the base ARC Simulator @<:@--with-cpu=qemu@:>@])],
+		[],
+		[with_sim=default]
+		)
+
+AS_IF([test "x$with_sim" != xdefault],
+	    [AC_SUBST(with_sim, $with_sim)],
+	    [AC_SUBST(with_sim,"qemu")])
+
+
 AC_ARG_ENABLE(werror,
         [AS_HELP_STRING([--enable-werror],
 		[controls if build is compiled with werror or not @<:@--disable-werror@:>@])],

--- a/scripts/wrapper/nsim/arc-elf32-run
+++ b/scripts/wrapper/nsim/arc-elf32-run
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+$NSIM_HOME/bin/nsimdrv \
+            -on nsim_isa_enable_timer_0             \
+            -on nsim_isa_enable_timer_1             \
+            -off invalid_instruction_interrupt      \
+            -off memory_exception_interrupt         \
+            -on nsim_download_elf_sections          \
+            -prop=nsim_emt=1                        \
+            -p nsim_isa_family=av2hs                \
+            -p nsim_isa_core=4                      \
+            -p nsim_isa_div_rem_option=2            \
+            -p nsim_isa_mpy64=1                     \
+            -p nsim_isa_div64_option=1              \
+            -p nsim_isa_unaligned_option=1          \
+            -p nsim_isa_atomic_option=1             \
+            -p nsim_isa_shift_option=0              \
+            -p nsim_isa_bitscan_option=0            \
+            -p nsim_isa_ll64_option=1               \
+            -p nsim_isa_fmp_sat_option=1            \
+            -p nsim_isa_mpy_option=9                \
+            -p nsim_isa_fpus_option=1               \
+            -p nsim_isa_fpud_option=1               \
+            -p nsim_isa_m128_option=1               \
+            -p nsim_isa_fpud_div_option=1           \
+            -p nsim_isa_fpu_mac_option=1            \
+            "$@"
+
+

--- a/scripts/wrapper/nsim/arc-elf32-run
+++ b/scripts/wrapper/nsim/arc-elf32-run
@@ -1,29 +1,29 @@
 #!/bin/bash
 
-$NSIM_HOME/bin/nsimdrv \
-            -on nsim_isa_enable_timer_0             \
-            -on nsim_isa_enable_timer_1             \
-            -off invalid_instruction_interrupt      \
-            -off memory_exception_interrupt         \
-            -on nsim_download_elf_sections          \
-            -prop=nsim_emt=1                        \
-            -p nsim_isa_family=av2hs                \
-            -p nsim_isa_core=4                      \
-            -p nsim_isa_div_rem_option=2            \
-            -p nsim_isa_mpy64=1                     \
-            -p nsim_isa_div64_option=1              \
-            -p nsim_isa_unaligned_option=1          \
-            -p nsim_isa_atomic_option=1             \
-            -p nsim_isa_shift_option=0              \
-            -p nsim_isa_bitscan_option=0            \
-            -p nsim_isa_ll64_option=1               \
-            -p nsim_isa_fmp_sat_option=1            \
-            -p nsim_isa_mpy_option=9                \
-            -p nsim_isa_fpus_option=1               \
-            -p nsim_isa_fpud_option=1               \
-            -p nsim_isa_m128_option=1               \
-            -p nsim_isa_fpud_div_option=1           \
-            -p nsim_isa_fpu_mac_option=1            \
-            "$@"
+nsimdrv \
+    -on nsim_isa_enable_timer_0             \
+    -on nsim_isa_enable_timer_1             \
+    -off invalid_instruction_interrupt      \
+    -off memory_exception_interrupt         \
+    -on nsim_download_elf_sections          \
+    -prop=nsim_emt=1                        \
+    -p nsim_isa_family=av2hs                \
+    -p nsim_isa_core=4                      \
+    -p nsim_isa_div_rem_option=2            \
+    -p nsim_isa_mpy64=1                     \
+    -p nsim_isa_div64_option=1              \
+    -p nsim_isa_unaligned_option=1          \
+    -p nsim_isa_atomic_option=1             \
+    -p nsim_isa_shift_option=0              \
+    -p nsim_isa_bitscan_option=0            \
+    -p nsim_isa_ll64_option=1               \
+    -p nsim_isa_fmp_sat_option=1            \
+    -p nsim_isa_mpy_option=9                \
+    -p nsim_isa_fpus_option=1               \
+    -p nsim_isa_fpud_option=1               \
+    -p nsim_isa_m128_option=1               \
+    -p nsim_isa_fpud_div_option=1           \
+    -p nsim_isa_fpu_mac_option=1            \
+    "$@"
 
 

--- a/scripts/wrapper/nsim/arc64-elf-run
+++ b/scripts/wrapper/nsim/arc64-elf-run
@@ -1,26 +1,26 @@
 #!/bin/bash
 
-$NSIM_HOME/bin/nsimdrv \
-            -on nsim_isa_enable_timer_0             \
-            -on nsim_isa_enable_timer_1             \
-            -off invalid_instruction_interrupt      \
-            -off memory_exception_interrupt         \
-            -on nsim_download_elf_sections          \
-            -prop=nsim_emt=1                        \
-            -p nsim_isa_family=arc64                \
-            -p nsim_isa_div_rem_option=2            \
-            -p nsim_isa_mpy_option=9                \
-            -p nsim_isa_mpy64=1                     \
-            -p nsim_isa_div64_option=1              \
-            -p nsim_isa_has_fp=1                    \
-            -p nsim_isa_fp_vec_option=1             \
-            -p nsim_isa_fp_hp_option=1              \
-            -p nsim_isa_fp_dp_option=1              \
-            -p nsim_isa_fp_div_option=1             \
-            -p nsim_isa_fp_num_regs=32              \
-            -p nsim_isa_unaligned_option=1          \
-            -p nsim_isa_atomic_option=1             \
-            -p nsim_isa_fp_wide_option=1            \
-            -p nsim_isa_shift_option=0              \
-            -p nsim_isa_bitscan_option=0            \
-            "$@"
+nsimdrv \
+    -on nsim_isa_enable_timer_0             \
+    -on nsim_isa_enable_timer_1             \
+    -off invalid_instruction_interrupt      \
+    -off memory_exception_interrupt         \
+    -on nsim_download_elf_sections          \
+    -prop=nsim_emt=1                        \
+    -p nsim_isa_family=arc64                \
+    -p nsim_isa_div_rem_option=2            \
+    -p nsim_isa_mpy_option=9                \
+    -p nsim_isa_mpy64=1                     \
+    -p nsim_isa_div64_option=1              \
+    -p nsim_isa_has_fp=1                    \
+    -p nsim_isa_fp_vec_option=1             \
+    -p nsim_isa_fp_hp_option=1              \
+    -p nsim_isa_fp_dp_option=1              \
+    -p nsim_isa_fp_div_option=1             \
+    -p nsim_isa_fp_num_regs=32              \
+    -p nsim_isa_unaligned_option=1          \
+    -p nsim_isa_atomic_option=1             \
+    -p nsim_isa_fp_wide_option=1            \
+    -p nsim_isa_shift_option=0              \
+    -p nsim_isa_bitscan_option=0            \
+    "$@"

--- a/scripts/wrapper/nsim/arc64-elf-run
+++ b/scripts/wrapper/nsim/arc64-elf-run
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+$NSIM_HOME/bin/nsimdrv \
+            -on nsim_isa_enable_timer_0             \
+            -on nsim_isa_enable_timer_1             \
+            -off invalid_instruction_interrupt      \
+            -off memory_exception_interrupt         \
+            -on nsim_download_elf_sections          \
+            -prop=nsim_emt=1                        \
+            -p nsim_isa_family=arc64                \
+            -p nsim_isa_div_rem_option=2            \
+            -p nsim_isa_mpy_option=9                \
+            -p nsim_isa_mpy64=1                     \
+            -p nsim_isa_div64_option=1              \
+            -p nsim_isa_has_fp=1                    \
+            -p nsim_isa_fp_vec_option=1             \
+            -p nsim_isa_fp_hp_option=1              \
+            -p nsim_isa_fp_dp_option=1              \
+            -p nsim_isa_fp_div_option=1             \
+            -p nsim_isa_fp_num_regs=32              \
+            -p nsim_isa_unaligned_option=1          \
+            -p nsim_isa_atomic_option=1             \
+            -p nsim_isa_fp_wide_option=1            \
+            -p nsim_isa_shift_option=0              \
+            -p nsim_isa_bitscan_option=0            \
+            "$@"


### PR DESCRIPTION
## Summary
Added new configuration option `--with-sim=SIM` used to determine the simulator for testing purposes. To run the desired tests, utilize the following command: `make check-newlib` for bare-metal, `make check-linux` for Linux, or `make report` for a test run culminating in a final report.

| Simulator  |   Option 	|
|--------------------------|:--------|
| QEMU  |  `--with-sim=qemu` (default)  | 
| nSIM  |     `--with-sim=nsim` |

When conducting tests for `newlib` and opting to use `nSIM` as the simulator, the tool must be in the environment variable `$PATH` to proceed.

`Note:` It should be noted that selecting nSIM is not possible if building the Linux Toolchain since it does not support user mode.


## Test Result
### ARC64
<table>
<tr><th>GCC</th><th>G++</th></tr>
<tr><td>

|           		           |   QEMU 	|   nSIM 	 |  
|--------------------------|---------:|---------:|
| of expected passes       |  129317  |  129317  |
| of unexpected failures   |      19  |      19  |
| of unexpected successes  |       2  |       2  |
| of expected failures     |     864  |     864  |
| of unresolved testcases  |      14  |      14  |
| of unsupported tests     |    5451  |    5451  |

</td><td>
  
|           		           |   QEMU 	|   nSIM   |  
|--------------------------|---------:|---------:|
| of expected passes       |  192300  |  192300  |
| of unexpected failures   |      11  |      11  |
| of unexpected successes  |      11  |      11  |
| of expected failures     |    1051  |    1051  |
| of unresolved testcases  |      -   |      -   |
| of unsupported tests     |   11039  |   11039  |

</td></tr> </table>



### ARCv2
<table>
<tr><th>GCC</th><th>G++</th></tr>
<tr><td>

|           		           |   QEMU 	|   nSIM 	 |  
|--------------------------|---------:|---------:|
| of expected passes       |  124966  |  126837  |
| of unexpected failures   |    1871  |      40  |
| of unexpected successes  |       4  |       4  |
| of expected failures     |     839  |     840  |
| of unresolved testcases  |      22  |      18  |
| of unsupported tests     |    3496  |    3496  |

</td><td>

|           		           |   QEMU 	|   nSIM   |  
|--------------------------|---------:|---------:|
| of expected passes       |  188816  |  189295  |
| of unexpected failures   |     483  |      19  |
| of unexpected successes  |      11  |      11  |
| of expected failures     |    1035  |    1035  |
| of unresolved testcases  |      -   |      -   |
| of unsupported tests     |   11029  |   11029  |

</td></tr> </table>

  
The significant difference in test results for ARCv2 between QEMU and nSIM is due to the absence of the floating point implementation, which is currently being reviewed in the pull request https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/pull/168 .

If using the `bruno_fpu_v2` branch, the results are the following:
<table>
<tr><th>GCC</th><th>G++</th></tr>
<tr><td>

|           		           |   QEMU 	|   nSIM 	 |  
|--------------------------|---------:|---------:|
| of expected passes       |  126834  |  126837  |
| of unexpected failures   |    41  |      40  |
| of unexpected successes  |       4  |       4  |
| of expected failures     |     840  |     840  |
| of unresolved testcases  |      20  |      18  |
| of unsupported tests     |    3496  |    3496  |

</td><td>

|           		           |   QEMU 	|   nSIM   |  
|--------------------------|---------:|---------:|
| of expected passes       |  189295  |  189295  |
| of unexpected failures   |     19  |      19  |
| of unexpected successes  |      11  |      11  |
| of expected failures     |    1035  |    1035  |
| of unresolved testcases  |      -   |      -   |
| of unsupported tests     |   11029  |   11029  |

</td></tr> </table>



## Disclaimer

When using the nSIM simulator, missing configurations, such as enabling STD instructions with `sim_isa_ll64_option=1`, can result in aborts. This will cause an abort with an error message similar to: `13:00:27.894801 ERROR:[CPU0] Encountered 
'InstructionError' exception while this exception is disabled in nSIM - halting. PC:0x000002c4 EFA:0x000002c4 ECR:0x00020000`. Interestingly, this abort is perceived as a PASS by dejagnu which is evident from the following message: 
```sh
spawn arc-elf32-run strrchr.x3 
ERROR:[CPU0] Encountered 'InstructionError' exception while this exception is disabled in nSIM - halting. PC:0x00000130 EFA:0x00000130 ERC:0x00020000 
PASS: gcc.c-torture/execute/buildins/strrchr.c execution, -O3 -g. 
```
Therefore, there could be an issue with how dejagnu interprets the abort exception from nSIM.
