### PR TITLE
Option for specifying custom parent source path

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,28 +23,33 @@ LINUX_BRANCH 		:= arc64
 
 
 BINUTILS_SRCDIR		:= @with_binutils_src@
-ifeq ($(BINUTILS_SRCDIR),)
-BINUTILS_SRCDIR		:= $(srcdir)/binutils-gdb
-endif
 NEWLIB_SRCDIR		:= @with_newlib_src@
-ifeq ($(NEWLIB_SRCDIR),)
-NEWLIB_SRCDIR		:= $(srcdir)/newlib
-endif
 GCC_SRCDIR		:= @with_gcc_src@
-ifeq ($(GCC_SRCDIR),)
-GCC_SRCDIR		:= $(srcdir)/gcc
-endif
 GLIBC_SRCDIR		:= @with_glibc_src@
-ifeq ($(GLIBC_SRCDIR),)
-GLIBC_SRCDIR		:= $(srcdir)/glibc
-endif
 LINUX_SRCDIR		:= @with_linux_src@
-ifeq ($(LINUX_SRCDIR),)
-LINUX_SRCDIR		:= $(srcdir)/linux
-endif
 QEMU_SRCDIR		:= @with_qemu_src@
-ifeq ($(QEMU_SRCDIR),)
-QEMU_SRCDIR		:= $(srcdir)/qemu
+
+PARENT_SRCDIR = @with_src@
+
+ifneq ($(PARENT_SRCDIR),)
+ifeq ($(BINUTILS_SRCDIR),$(srcdir)/binutils-gdb)
+BINUTILS_SRCDIR = $(PARENT_SRCDIR)/binutils-gdb
+endif
+ifeq ($(NEWLIB_SRCDIR),$(srcdir)/newlib)
+NEWLIB_SRCDIR = $(PARENT_SRCDIR)/newlib
+endif
+ifeq ($(GCC_SRCDIR),$(srcdir)/gcc)
+GCC_SRCDIR = $(PARENT_SRCDIR)/gcc
+endif
+ifeq ($(GLIBC_SRCDIR),$(srcdir)/glibc)
+GLIBC_SRCDIR = $(PARENT_SRCDIR)/glibc
+endif
+ifeq ($(LINUX_SRCDIR),$(srcdir)/linux)
+LINUX_SRCDIR = $(PARENT_SRCDIR)/linux
+endif
+ifeq ($(QEMU_SRCDIR),$(srcdir)/qemu)
+QEMU_SRCDIR = $(PARENT_SRCDIR)/qemu
+endif
 endif
 
 SYSROOT := $(INSTALL_DIR)/sysroot

--- a/README.md
+++ b/README.md
@@ -17,18 +17,22 @@ newlib
 glibc
 ```
 
-If they do not exist, it will clone them. You can link your source directories
-from other palces as well:
+If they do not exist, it will clone them.
 
-```sh
-cd    /repos/arc-gnu-toolchain
-ln -s /repos/tools/binutils  binutils-gdb
-ln -s /repos/tools/gcc       gcc
-ln -s /repos/tools/newlib    newlib
-ln -s /repos/tools/glibc     glibc
+The `arc-gnu-toolchain` also provides the capability to build the toolchain using source code located outside of the main repository. There are specific configuration options available to define the source directory for each component or for a parent directory.
 
-cd    /build/arc64
-/repos/arc-gnu-toolchain/configure ...
+As an example, if you have an external GCC source, you can use the `--with-gcc-src` option to specify it:
+
+```bash
+
+./configure --with-gcc-src=/path/to/gcc
+```
+
+Similarly, if you have an external parent directory that encompasses all the sources, you can use the `--with-src` option to inicate its location:
+
+```bash
+
+./configure --with-src=/path/to/parent
 ```
 
 For a 64-bit linux build, you will need the following branches:
@@ -122,17 +126,24 @@ make install
 
 Some of parameters you can pass to the configure script:
 
-| parameter           | default | values                                                                          |
-|---------------------|---------|---------------------------------------------------------------------------------|
-| --target            |         | arc64, arc32, arc                                                               |
-| --prefix            |         | any path string for installation                                                |
-| --enable-linux      | no      | yes, no (--disable-linux)                                                       |
-| --enable-multilib   | no      | yes, no (--disable-multilib)                                                    |
-| --enable-qemu       | no      | yes, no (--disable-qemu)                                                        |
-| --enable-debug-info | no      | yes, no (--disable-debug-info)                                                  |
-| --with-fpu          | none    | none, fpus, fpud                                                                |
-| --with-cpu          | none    | none, hs6x, hs68, hs5x, hs58, archs, (more at binutils/include/elf/arc-cpu.def) |
-| --with-sim          | qemu    | qemu, nsim                                                                      |
+| parameter           | default           | values                                                                          |
+|---------------------|-------------------|---------------------------------------------------------------------------------|
+| --target            |                   | arc64, arc32, arc                                                               |
+| --prefix            |                   | any path string for installation                                                |
+| --enable-linux      | no                | yes, no (--disable-linux)                                                       |
+| --enable-multilib   | no                | yes, no (--disable-multilib)                                                    |
+| --enable-qemu       | no                | yes, no (--disable-qemu)                                                        |
+| --enable-debug-info | no                | yes, no (--disable-debug-info)                                                  |
+| --with-fpu          | none              | none, fpus, fpud                                                                |
+| --with-cpu          | none              | none, hs6x, hs68, hs5x, hs58, archs, (more at binutils/include/elf/arc-cpu.def) |
+| --with-sim          | qemu              | qemu, nsim                                                                      |
+| --with-src          | arc-gnu-toolchain | /path/to/parent                                                                 |
+| --with-binutils-src | ./binutils-gdb    | /path/to/binutils-gdb                                                           |
+| --with-newlib-src   | ./newlib          | /path/to/newlib                                                                 |
+| --with-gcc-src      | ./gcc             | /path/to/gcc                                                                    |
+| --with-glibc-src    | ./glibc           | /path/to/glibc                                                                  |
+| --with-linux-src    | ./linux           | /path/to/linux                                                                  |
+| --with-qemu-src     | ./qemu            | /path/to/qemu                                                                   |
 
 ### Advanced Options
 

--- a/configure.ac
+++ b/configure.ac
@@ -177,12 +177,22 @@ AC_DEFUN([AX_ARG_WITH_SRC],
 	  m4_popdef([opt_name])
 	}])
 
-AX_ARG_WITH_SRC(binutils, binutils)
+AX_ARG_WITH_SRC(binutils, binutils-gdb)
 AX_ARG_WITH_SRC(newlib, newlib)
 AX_ARG_WITH_SRC(gcc, gcc)
 AX_ARG_WITH_SRC(glibc, glibc)
 AX_ARG_WITH_SRC(linux, linux)
 AX_ARG_WITH_SRC(qemu, qemu)
+
+AC_ARG_WITH(src,
+	[AS_HELP_STRING([--with-src],
+		[Select parent source path, use `arc-gnu-toolchain` as parent source path by default])],
+	[],
+	[]
+	)
+AS_IF([test "x$with_src" != x],
+    [AC_SUBST(with_src, $with_src)],
+	[AC_SUBST(with_src, "")])
 
 
 AC_ARG_WITH(target_cflags,


### PR DESCRIPTION
Set the parent source path with `--with-src` (e.i --with-src=/path/to/parent)
Use `arc-gnu-toolchain` as parent source by default.