### PR TITLE
Excluded GNU AS and GNU LD

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -360,8 +360,6 @@ stamps/build-gcc-linux-stage1: $(GCC_SRCDIR) stamps/build-binutils-linux \
 		@with_fpu@ \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
-		--with-gnu-as \
-		--with-gnu-ld \
 		CFLAGS="$(CFLAGS)" \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CFLAGS_FOR_BUILD="$(CFLAGS_FOR_BUILD)" \
@@ -397,8 +395,6 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) stamps/build-glibc-linux \
 		@with_fpu@ \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
-		--with-gnu-as \
-		--with-gnu-ld \
 		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET) $(DEBUG_INFO)" \
 		CFLAGS_FOR_BUILD="$(CFLAGS_FOR_BUILD) $(DEBUG_INFO)" \
@@ -487,8 +483,6 @@ stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) stamps/build-binutils-newlib
 		@werror_flag@ \
 		$(WITH_CPU) \
 		@with_fpu@ \
-		--with-gnu-as \
-		--with-gnu-ld \
 		CFLAGS="$(CFLAGS)" \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CFLAGS_FOR_BUILD="$(CFLAGS_FOR_BUILD)" \
@@ -542,8 +536,6 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) stamps/build-newlib
 		@werror_flag@ \
 		$(WITH_CPU) \
 		@with_fpu@ \
-		--with-gnu-as \
-		--with-gnu-ld \
 		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET) $(DEBUG_INFO)" \
 		CFLAGS_FOR_BUILD="$(CFLAGS_FOR_BUILD) $(DEBUG_INFO)" \


### PR DESCRIPTION
Excluded the need for GNU AS and GNU LD configuration in the Toolchain settings, as these configurations have now been transfered to the GCC driver.

Issue: https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/421
GCC PR: https://github.com/foss-for-synopsys-dwc-arc-processors/gcc/pull/117