### PR TITLE
Rectified inaccurate Argument in nSIM Wrapper Configuration.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -140,6 +140,11 @@ endif
 ifeq ($(SIM),qemu)
 	# Using qemu simulator.
 	SIM_STAMP:= stamps/build-qemu
+	SIM_PATH:=$(srcdir)/scripts/wrapper/$(SIM)
+	SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" ARC_SYSROOT="$(SYSROOT)" DEJAGNU="$(srcdir)/dejagnu/site.exp" QEMU_CPU="$(QEMU_CPU)"
+ifeq (@default_target@,baremetal)
+	SIM_PREPARE:=$(SIM_PREPARE) DEJAGNU_SIM_OPTIONS="-Wq,-semihosting"
+endif
 else
 ifeq ($(SIM),nsim)
 	# Using nsim simulator.
@@ -147,13 +152,13 @@ ifeq ($(SIM),nsim)
 		$(error nSIM not supported)
 	endif
 	SIM_STAMP:= nsim-validation
+	SIM_PATH:=$(srcdir)/scripts/wrapper/$(SIM)
+	SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" ARC_SYSROOT="$(SYSROOT)" DEJAGNU="$(srcdir)/dejagnu/site.exp" QEMU_CPU="$(QEMU_CPU)"
 else
 	$(error Only support SIM=nsim, or SIM=qemu (default))
 endif
 endif
 
-SIM_PATH:=$(srcdir)/scripts/wrapper/$(SIM)
-SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" ARC_SYSROOT="$(SYSROOT)" DEJAGNU="$(srcdir)/dejagnu/site.exp" QEMU_CPU="$(QEMU_CPU)"
 
 all: @default_target@ @qemu_build@
 	echo "$(INSTALL_DIR)" > stamps/install_dir
@@ -589,12 +594,12 @@ stamps/check-gcc-linux: stamps/build-gcc-linux-stage2 $(SIM_STAMP)
 	date > $@
 
 stamps/check-gcc-baremetal: stamps/build-gcc-newlib-stage2 $(SIM_STAMP)
-	$(SIM_PREPARE) DEJAGNU_SIM_OPTIONS="-Wq,-semihosting" $(MAKE) -C build-gcc-newlib-stage2 check-gcc "RUNTESTFLAGS=$(RUNTESTFLAGS) --target_board='$(NEWLIB_TARGET_BOARDS)'"
+	$(SIM_PREPARE) $(MAKE) -C build-gcc-newlib-stage2 check-gcc "RUNTESTFLAGS=$(RUNTESTFLAGS) --target_board='$(NEWLIB_TARGET_BOARDS)'"
 	mkdir -p $(dir $@)
 	date > $@
 
 stamps/check-binutils-baremetal: stamps/build-gcc-newlib-stage2 $(SIM_STAMP)
-	$(SIM_PREPARE) DEJAGNU_SIM_OPTIONS="-Wq,-semihosting" $(MAKE) -C build-binutils-newlib check-binutils check-gas check-ld -k "RUNTESTFLAGS=--target_board='$(NEWLIB_TARGET_BOARDS)'" || true
+	$(SIM_PREPARE) $(MAKE) -C build-binutils-newlib check-binutils check-gas check-ld -k "RUNTESTFLAGS=--target_board='$(NEWLIB_TARGET_BOARDS)'" || true
 	date > $@
 
 stamps/check-binutils-linux: stamps/build-gcc-linux-stage2 $(SIM_STAMP)
@@ -602,7 +607,7 @@ stamps/check-binutils-linux: stamps/build-gcc-linux-stage2 $(SIM_STAMP)
 	date > $@
 
 stamps/check-newlib-baremetal: stamps/build-newlib $(SIM_STAMP)
-	$(SIM_PREPARE) DEJAGNU_SIM_OPTIONS="-Wq,-semihosting" $(MAKE) -C build-newlib check -k "RUNTESTFLAGS=--target_board='$(NEWLIB_TARGET_BOARDS)'" || true
+	$(SIM_PREPARE) $(MAKE) -C build-newlib check -k "RUNTESTFLAGS=--target_board='$(NEWLIB_TARGET_BOARDS)'" || true
 	date > $@
 
 nsim-validation:


### PR DESCRIPTION
With the integration of the QEMU testsuite, a change in the configuration arguments for the QEMU wrapper was introduced. The `-semihosting` flag, previously directly applied in the wrapper, has been removed and is now provided as an argument `-Wq,-semihosting`. This adjustment was necessary because the QEMU Testsuite does not support enabling the flag in its former fashion.

This commit addresses the issue where `-Wq,semihosting` was improperly passed to the nSIM wrapper, causing a crash.