### PR TITLE
Explicitly set the environment version to exlude extra build errors

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,7 +53,7 @@ jobs:
 
   create-release:
     needs: toolchains
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The purpose of this commit is to provide predictable behaviour for the build process. It is necessary because another project (https://github.com/foss-for-synopsys-dwc-arc-processors/linux) also depends on this CI. The environment version can be changed later as the project progresses, but don't forget to change the dependent projects too.