### PR TITLE
Isolate GDB from binutils-gdb build system.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,6 +14,7 @@ SNPS_GIT_URL    	:= https://github.com/foss-for-synopsys-dwc-arc-processors
 BINUTILS_BRANCH 	:= arc-2025.06
 GCC_BRANCH      	:= arc-2025.06
 NEWLIB_BRANCH   	:= arc-2025.06
+GDB_BRANCH 		:= arc-2025.06-gdb
 QEMU_BRANCH     	:= master
 GLIBC_BRANCH    	:= arc-2025.06
 BUILDROOT_BRANCH	:= arc64
@@ -23,6 +24,7 @@ LINUX_BRANCH 		:= arc64
 
 
 BINUTILS_SRCDIR		:= @with_binutils_src@
+GDB_SRCDIR		:= @with_gdb_src@
 NEWLIB_SRCDIR		:= @with_newlib_src@
 GCC_SRCDIR		:= @with_gcc_src@
 GLIBC_SRCDIR		:= @with_glibc_src@
@@ -32,8 +34,11 @@ QEMU_SRCDIR		:= @with_qemu_src@
 PARENT_SRCDIR = @with_src@
 
 ifneq ($(PARENT_SRCDIR),)
-ifeq ($(BINUTILS_SRCDIR),$(srcdir)/binutils-gdb)
-BINUTILS_SRCDIR = $(PARENT_SRCDIR)/binutils-gdb
+ifeq ($(BINUTILS_SRCDIR),$(srcdir)/binutils)
+BINUTILS_SRCDIR = $(PARENT_SRCDIR)/binutils
+endif
+ifeq ($(GDB_SRCDIR),$(srcdir)/gdb)
+GDB_SRCDIR = $(PARENT_SRCDIR)/gdb
 endif
 ifeq ($(NEWLIB_SRCDIR),$(srcdir)/newlib)
 NEWLIB_SRCDIR = $(PARENT_SRCDIR)/newlib
@@ -163,7 +168,9 @@ endif
 all: @default_target@ @qemu_build@
 	echo "$(INSTALL_DIR)" > stamps/install_dir
 baremetal: stamps/build-gcc-newlib-stage2
+baremetal: stamps/build-gdb-newlib
 linux: stamps/build-gdbserver-linux
+linux: stamps/build-gdb-linux
 
 gdbserver: stamps/build-gdbserver-linux
 qemu: stamps/build-qemu
@@ -187,6 +194,10 @@ check-gcc-linux: stamps/check-gcc-linux
 check-binutils: check-binutils-@default_target@
 check-binutils-linux: stamps/check-binutils-linux
 check-binutils-baremetal: stamps/check-binutils-baremetal
+
+check-gdb: check-gdb-@default_target@
+check-gdb-linux: stamps/check-gdb-linux
+check-gdb-baremetal: stamps/check-gdb-baremetal
 
 check-qemu: check-qemu-@default_target@
 check-qemu-baremetal: stamps/check-qemu-baremetal
@@ -229,6 +240,9 @@ patches: $(addprefix $(srcdir)/patches/,$(PACKAGES))
 
 $(BINUTILS_SRCDIR):
 	git clone --depth 1 --single-branch --branch $(BINUTILS_BRANCH) $(SNPS_GIT_URL)/binutils-gdb.git $@
+
+$(GDB_SRCDIR):
+	git clone --depth 1 --single-branch --branch $(GDB_BRANCH) $(SNPS_GIT_URL)/binutils-gdb.git $@
 
 $(GCC_SRCDIR):
 	git clone --depth 1 --single-branch --branch $(GCC_BRANCH) $(SNPS_GIT_URL)/gcc.git $@
@@ -279,9 +293,38 @@ stamps/build-binutils-linux: $(BINUTILS_SRCDIR) stamps/check-write-permission
 		--with-sysroot=$(SYSROOT) \
 		$(MULTILIB_FLAGS) \
 		--disable-werror \
+		--disable-gdb \
 		--disable-nls \
 		$(BINUTILS_TARGET_FLAGS) \
 		--disable-sim \
+		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
+		CFLAGS_FOR_TARGET="$(CFLAGS_FOR_TARGET) $(DEBUG_INFO)" \
+		CFLAGS_FOR_BUILD="$(CFLAGS_FOR_BUILD) $(DEBUG_INFO)" \
+		CXXFLAGS="$(CXXFLAGS) $(DEBUG_INFO)" \
+		CXXFLAGS_FOR_TARGET="$(CXXFLAGS_FOR_TARGET) $(DEBUG_INFO)" \
+		CXXFLAGS_FOR_BUILD="$(CXXFLAGS_FOR_BUILD) $(DEBUG_INFO)"
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gdb-linux: $(GDB_SRCDIR) $(GDB_SRC_GIT) stamps/build-gcc-linux-stage2
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		--target=$(LINUX_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR) \
+		--with-sysroot=$(SYSROOT) \
+		$(MULTILIB_FLAGS) \
+		--disable-werror \
+		--disable-nls \
+		$(GDB_TARGET_FLAGS) \
+		--enable-gdb \
+		--disable-gas \
+		--disable-binutils \
+		--disable-ld \
+		--disable-gold \
+		--disable-gprof \
 		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
 		CFLAGS_FOR_TARGET="$(CFLAGS_FOR_TARGET) $(DEBUG_INFO)" \
 		CFLAGS_FOR_BUILD="$(CFLAGS_FOR_BUILD) $(DEBUG_INFO)" \
@@ -411,7 +454,7 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) stamps/build-glibc-linux \
 	cp -a $(INSTALL_DIR)/$(LINUX_TUPLE)/lib* $(SYSROOT)
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gdbserver-linux: $(BINUTILS_SRCDIR) stamps/build-gcc-linux-stage2
+stamps/build-gdbserver-linux: $(GDB_SRCDIR) stamps/build-gcc-linux-stage2
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure                  \
@@ -453,6 +496,31 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR)
 		--target=$(NEWLIB_TUPLE) \
 		--prefix=$(INSTALL_DIR) \
 		--disable-python \
+		--disable-gdb \
+		@multilib_flags@ \
+		@werror_flag@ \
+		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
+		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET) $(DEBUG_INFO)" \
+		CFLAGS_FOR_BUILD="$(CFLAGS_FOR_BUILD) $(DEBUG_INFO)" \
+		CXXFLAGS="$(CXXFLAGS) $(DEBUG_INFO)" \
+		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET) $(DEBUG_INFO)" \
+		CXXFLAGS_FOR_BUILD="$(CXXFLAGS_FOR_BUILD) $(DEBUG_INFO)"
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gdb-newlib: $(GDB_SRCDIR) $(GDB_SRC_GIT)
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		--target=$(NEWLIB_TUPLE) \
+		--prefix=$(INSTALL_DIR) \
+		--enable-gdb \
+		--disable-gas \
+		--disable-binutils \
+		--disable-ld \
+		--disable-gold \
+		--disable-gprof \
 		@multilib_flags@ \
 		@werror_flag@ \
 		CFLAGS="$(CFLAGS) $(DEBUG_INFO)" \
@@ -594,8 +662,16 @@ stamps/check-binutils-baremetal: stamps/build-gcc-newlib-stage2 $(SIM_STAMP)
 	$(SIM_PREPARE) $(MAKE) -C build-binutils-newlib check-binutils check-gas check-ld -k "RUNTESTFLAGS=--target_board='$(NEWLIB_TARGET_BOARDS)'" || true
 	date > $@
 
+stamps/check-gdb-baremetal: stamps/build-gcc-newlib-stage2 stamps/build-gdb-newlib $(SIM_STAMP)
+	$(SIM_PREPARE) $(MAKE) -C build-gdb-newlib check-gdb -k "RUNTESTFLAGS=--target_board='$(NEWLIB_TARGET_BOARDS)'" || true
+	date > $@
+
 stamps/check-binutils-linux: stamps/build-gcc-linux-stage2 $(SIM_STAMP)
 	$(SIM_PREPARE) $(MAKE) -C build-binutils-linux check-binutils check-gas check-ld -k "RUNTESTFLAGS=--target_board='$(GLIBC_TARGET_BOARDS)'" || true
+	date > $@
+
+stamps/check-gdb-linux: stamps/build-gcc-linux-stage2 stamps/build-gdb-linux $(SIM_STAMP)
+	$(SIM_PREPARE) $(MAKE) -C build-gdb-linux check-gdb -k "RUNTESTFLAGS=--target_board='$(GLIBC_TARGET_BOARDS)'" || true
 	date > $@
 
 stamps/check-newlib-baremetal: stamps/build-newlib $(SIM_STAMP)

--- a/Makefile.in
+++ b/Makefile.in
@@ -11,11 +11,11 @@ newlib_url := ftp://sourceware.org/pub/newlib/newlib-$(newlib_version).tar.gz
 
 # SNPS toolchains
 SNPS_GIT_URL    	:= https://github.com/foss-for-synopsys-dwc-arc-processors
-BINUTILS_BRANCH 	:= arc64
-GCC_BRANCH      	:= arc64
-NEWLIB_BRANCH   	:= arc64
+BINUTILS_BRANCH 	:= arc-2025.06
+GCC_BRANCH      	:= arc-2025.06
+NEWLIB_BRANCH   	:= arc-2025.06
 QEMU_BRANCH     	:= master
-GLIBC_BRANCH    	:= arc64
+GLIBC_BRANCH    	:= arc-2025.06
 BUILDROOT_BRANCH	:= arc64
 LINUX_BRANCH 		:= arc64
 

--- a/configure.ac
+++ b/configure.ac
@@ -177,7 +177,8 @@ AC_DEFUN([AX_ARG_WITH_SRC],
 	  m4_popdef([opt_name])
 	}])
 
-AX_ARG_WITH_SRC(binutils, binutils-gdb)
+AX_ARG_WITH_SRC(binutils, binutils)
+AX_ARG_WITH_SRC(gdb, gdb)
 AX_ARG_WITH_SRC(newlib, newlib)
 AX_ARG_WITH_SRC(gcc, gcc)
 AX_ARG_WITH_SRC(glibc, glibc)


### PR DESCRIPTION
The development binutils branch does not contain the latest
patches from gdb as it has now its own branch (currently
arc-2025.06-gdb).

This patch seperates gdb build system from binutils.