### PR TITLE
Enable status wrapper for ARC baseboard.

### DIFF
--- a/dejagnu/baseboards/arc-sim.exp
+++ b/dejagnu/baseboards/arc-sim.exp
@@ -67,3 +67,5 @@ set_board_info gdb,use_precord 0
 
 # Setup the timeout
 set_board_info gcc,timeout 600
+
+set_board_info needs_status_wrapper 1


### PR DESCRIPTION
Add `needs_status_wrapper` to the ARC simulator
baseboard in DejaGNU so that simulator returns
the exit code of the tests instead of its own.