### PR TITLE
allowlist: Add loop versioning pass new failures

### DIFF
--- a/test/allowlist/gcc/arc600/newlib.log
+++ b/test/allowlist/gcc/arc600/newlib.log
@@ -73,6 +73,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -241,3 +255,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/arc700/newlib.log
+++ b/test/allowlist/gcc/arc700/newlib.log
@@ -83,6 +83,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -250,3 +264,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/arcem/newlib.log
+++ b/test/allowlist/gcc/arcem/newlib.log
@@ -56,6 +56,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -223,3 +237,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/archs/newlib.log
+++ b/test/allowlist/gcc/archs/newlib.log
@@ -47,6 +47,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# GCC 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -218,3 +232,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/em/newlib.log
+++ b/test/allowlist/gcc/em/newlib.log
@@ -73,6 +73,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# GCC 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -240,3 +254,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/em4/newlib.log
+++ b/test/allowlist/gcc/em4/newlib.log
@@ -1,0 +1,82 @@
+#
+# arc600 CPU (2025.09 release known failures.)
+#
+FAIL: gcc.dg/debug/btf/btf-datasec-1.c scan-assembler-times 0[\t ]+[^\n]*bts_offset 7
+FAIL: gcc.dg/debug/btf/btf-datasec-1.c scan-assembler-times 0xf000001[\t ]+[^\n]*btt_info 1
+FAIL: gcc.dg/debug/btf/btf-datasec-1.c scan-assembler-times 0xf000003[\t ]+[^\n]*btt_info 2
+FAIL: gcc.dg/debug/btf/btf-datasec-1.c scan-assembler-times ascii ".data.0"[\t ]+[^\n]*btf_aux_string 1
+FAIL: gcc.dg/memcmp-1.c execution test
+FAIL: gcc.dg/pr114713.c execution test
+FAIL: gcc.dg/torture/inline-mem-cmp-1.c   -O0  execution test
+FAIL: gcc.dg/torture/inline-mem-cmp-1.c   -O1  execution test
+FAIL: gcc.dg/torture/inline-mem-cmp-1.c   -O2  execution test
+FAIL: gcc.dg/torture/inline-mem-cmp-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+FAIL: gcc.dg/torture/inline-mem-cmp-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+FAIL: gcc.dg/torture/inline-mem-cmp-1.c   -O3 -g  execution test
+FAIL: gcc.dg/torture/inline-mem-cmp-1.c   -Os  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-1.c   -O0  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-1.c   -O1  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-1.c   -O2  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-1.c   -O3 -g  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-1.c   -Os  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-cmp-1.c   -O0  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-cmp-1.c   -O1  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-cmp-1.c   -O2  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-cmp-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-cmp-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-cmp-1.c   -O3 -g  execution test
+FAIL: gcc.dg/torture/inline-mem-cpy-cmp-1.c   -Os  execution test
+FAIL: gcc.dg/torture/pr113026-1.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions   (test for bogus messages, line 10)
+FAIL: gcc.dg/tree-prof/indir-call-prof-malloc.c compilation,  -fprofile-generate -D_PROFILE_GENERATE
+FAIL: gcc.dg/tree-prof/pr97461.c compilation,  -fprofile-generate -D_PROFILE_GENERATE
+FAIL: gcc.dg/tree-prof/stringop-1.c scan-ipa-dump profile "Transformation done: single value 4 stringop"
+FAIL: gcc.dg/tree-prof/stringop-1.c scan-tree-dump optimized " = MEM.*&b"
+FAIL: gcc.dg/tree-prof/stringop-1.c scan-tree-dump optimized "MEM.*&a\\] = "
+FAIL: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-generate -D_PROFILE_GENERATE
+FAIL: gcc.dg/tree-ssa/pr83403-1.c scan-tree-dump-times lim2 "Executing store motion of" 10
+FAIL: gcc.dg/tree-ssa/pr83403-2.c scan-tree-dump-times lim2 "Executing store motion of" 10
+FAIL: gcc.dg/tree-ssa/slsr-13.c scan-tree-dump-times optimized " \\* 4" 2
+FAIL: gcc.dg/tree-ssa/slsr-13.c scan-tree-dump-times optimized " \\* 5" 0
+FAIL: gcc.dg/tree-ssa/update-threading.c scan-tree-dump-times optimized "Invalid sum" 0
+FAIL: gcc.dg/tree-ssa/vrp-loop-1.c scan-tree-dump-not optimized "foo "
+FAIL: gcc.target/arc/add_n-combine.c scan-assembler @at1\\+1
+FAIL: gcc.target/arc/jumptable.c scan-assembler-times b_s 6
+FAIL: gcc.target/arc/mov-cnst-size.c scan-assembler asl_s\\s+r0,r0,13
+FAIL: gcc.target/arc/mov-cnst-size.c scan-assembler lsl16\\s+r0,63
+FAIL: gcc.target/arc/mov-cnst-size.c scan-assembler lsl8\\s+r0,63
+FAIL: gcc.target/arc/mov-cnst-size.c scan-assembler mov_s\\s+r0,17
+FAIL: gcc.target/arc/mov-cnst-size.c scan-assembler ror8\\s+r0,63
+FAIL: gcc.target/arc/mult-cmp0.c scan-assembler-times mpy\\.f\\s+0 2
+FAIL: gcc.target/arc/mult-cmp0.c scan-assembler-times mpy\\.f\\s+r 2
+
+UNRESOLVED: gcc.dg/torture/pr23821.c   -Os   scan-tree-dump ivcanon "Added canonical iv"
+UNRESOLVED: gcc.dg/tree-prof/indir-call-prof-malloc.c compilation,  -fprofile-use -D_PROFILE_USE
+UNRESOLVED: gcc.dg/tree-prof/indir-call-prof-malloc.c execution,    -fprofile-generate -D_PROFILE_GENERATE
+UNRESOLVED: gcc.dg/tree-prof/indir-call-prof-malloc.c execution,    -fprofile-use -D_PROFILE_USE
+UNRESOLVED: gcc.dg/tree-prof/pr97461.c compilation,  -fprofile-use -D_PROFILE_USE
+UNRESOLVED: gcc.dg/tree-prof/pr97461.c execution,    -fprofile-generate -D_PROFILE_GENERATE
+UNRESOLVED: gcc.dg/tree-prof/pr97461.c execution,    -fprofile-use -D_PROFILE_USE
+UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PROFILE_USE
+UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-generate -D_PROFILE_GENERATE
+UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
+UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
+#
+# g++
+#

--- a/test/allowlist/gcc/em4_fpuda/newlib.log
+++ b/test/allowlist/gcc/em4_fpuda/newlib.log
@@ -38,6 +38,20 @@ UNRESOLVED: gcc.target/arc/mdpfp.c scan-assembler daddh
 UNRESOLVED: gcc.target/arc/mspfp.c scan-assembler fadd
 UNRESOLVED: gcc.target/arc/no-dpfp-lrsr.c scan-assembler-not \tlr
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -205,3 +219,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/hs/newlib.log
+++ b/test/allowlist/gcc/hs/newlib.log
@@ -34,6 +34,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# GCC 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -201,3 +215,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/hs34/newlib.log
+++ b/test/allowlist/gcc/hs34/newlib.log
@@ -33,6 +33,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -200,3 +214,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/hs38_linux/newlib.log
+++ b/test/allowlist/gcc/hs38_linux/newlib.log
@@ -41,6 +41,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -211,3 +225,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/hs4xd/newlib.log
+++ b/test/allowlist/gcc/hs4xd/newlib.log
@@ -41,6 +41,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -211,3 +225,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/hs58/newlib.log
+++ b/test/allowlist/gcc/hs58/newlib.log
@@ -57,6 +57,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -220,3 +234,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/hs5x/newlib.log
+++ b/test/allowlist/gcc/hs5x/newlib.log
@@ -55,6 +55,20 @@ UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c compilation,  -fprofile-use -D_PR
 UNRESOLVED: gcc.dg/tree-prof/time-profiler-2.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -218,3 +232,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/hs68/newlib.log
+++ b/test/allowlist/gcc/hs68/newlib.log
@@ -41,6 +41,20 @@ UNRESOLVED: gcc.dg/tree-prof/val-profiler-threads-1.c compilation,  -fprofile-us
 UNRESOLVED: gcc.dg/tree-prof/val-profiler-threads-1.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -204,3 +218,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0

--- a/test/allowlist/gcc/hs6x/newlib.log
+++ b/test/allowlist/gcc/hs6x/newlib.log
@@ -31,6 +31,20 @@ UNRESOLVED: gcc.dg/tree-prof/val-profiler-threads-1.c compilation,  -fprofile-us
 UNRESOLVED: gcc.dg/tree-prof/val-profiler-threads-1.c execution,    -fprofile-use -D_PROFILE_USE
 UNRESOLVED: gcc.dg/tree-ssa/ldist-37.c scan-tree-dump ldist "split to 0 loops and 1 library calls"
 
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: gcc.dg/pr103079.c scan-tree-dump vrp2 "PHI"
+UNRESOLVED: gcc.dg/pr110582.c scan-tree-dump-not vrp2 "Folding predicate"
+UNRESOLVED: gcc.dg/pr110875.c scan-tree-dump-not vrp2 "foo"
+UNRESOLVED: gcc.dg/pr93917.c scan-tree-dump-times vrp2 "__builtin_unreachable" 0
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MAX_EXPR" 1
+UNRESOLVED: gcc.dg/vrp-min-max-2.c scan-tree-dump-times vrp2 "MIN_EXPR" 1
+UNRESOLVED: gcc.dg/tree-ssa/pr68234.c scan-tree-dump vrp2 ">> 6"
+UNRESOLVED: gcc.dg/tree-ssa/pr70232.c scan-tree-dump-not vrp2 "Registering jump "
+UNRESOLVED: gcc.dg/tree-ssa/vrp-float-plus.c scan-tree-dump-times vrp2 "return 2\\.0e" 1
+UNRESOLVED: gcc.dg/tree-ssa/vrp-unreachable.c scan-tree-dump-not vrp2 "builtin_unreachable"
+UNRESOLVED: gcc.dg/tree-ssa/vrp47.c scan-tree-dump-times vrp2 " & 1;" 0
+UNRESOLVED: gcc.dg/tree-ssa/vrp91.c scan-tree-dump vrp2 "\\[0, 7\\]"
+
 #
 # g++
 #
@@ -194,3 +208,20 @@ XPASS: g++.dg/torture/pr101373.C   -O3 -g  execution test
 XPASS: g++.dg/torture/pr101373.C   -Os  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
 XPASS: g++.dg/torture/pr101373.C   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+
+# 544ca304b8222b5bd98776778e3d48c6a7ec2436 loop versioning pass patch introduced the following failures:
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++11  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++17  scan-tree-dump-times vrp2 "return 1" 4
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 0" 0
+UNRESOLVED: g++.dg/cpp23/attr-assume-opt.C  -std=gnu++26  scan-tree-dump-times vrp2 "return 1" 4
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++17  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++26  scan-tree-dump optimized "barvar"
+FAIL: g++.dg/ipa/pure-const-3.C  -std=gnu++98  scan-tree-dump optimized "barvar"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++17  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++26  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/pr104547.C  -std=gnu++98  scan-tree-dump-not vrp2 "_M_default_append"
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++17  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++26  scan-tree-dump-times vrp2 "Folding predicate.*45" 0
+UNRESOLVED: g++.dg/tree-ssa/pr49911.C  -std=gnu++98  scan-tree-dump-times vrp2 "Folding predicate.*45" 0


### PR DESCRIPTION
The "ivbound: Introduce loop versioning pass for potentially overflowing IV's" patch [0] has introduced new failures.  Adding them on the allowlist for the time being.

[0] https://github.com/foss-for-synopsys-dwc-arc-processors/gcc/commit/544ca304b8222b5bd98776778e3d48c6a7ec2436